### PR TITLE
Misc improvements to lumo build

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,35 @@ equivalent functionality).
 In the example above, there needn't be a corresponding entry for `echo` in
 `project.clj`.
 
+#### Lumo compiler
+
+Alternatively you can use the [Lumo](https://github.com/anmonteiro/lumo)
+[compiler](https://anmonteiro.com/2017/02/compiling-clojurescript-projects-without-the-jvm/).
+
+In order to enable it either pass the `--lumo` switch to either `deploy` or `package`:
+
+```shell
+serverless deploy --lumo
+```
+
+Or add the following to your `serverless.yml`:
+
+```yaml
+custom:
+  cljsCompiler: lumo
+```
+
+The source paths and compiler options will be read from `serverless-lumo.edn`:
+
+```clojure
+{:source-paths ["src"]
+ :compiler-options {:output-to     "out/my/artifact.js" ;; defaults to out/lambda.js
+                    :output-dir    "out/my"             ;; defaults to out
+                    :optimizations :simple              ;; defaults to :none
+                    :source-map    false                ;; defaults to false because of lumo bug #132
+                    ...other options...}}
+```
+
 ## License
 
 serverless-cljs-plugin is free and unencumbered public domain software. For more

--- a/index.js
+++ b/index.js
@@ -52,8 +52,10 @@ function basepath(config, service, opts) {
 
 function cljsLambdaBuild(serverless, opts) {
   const fns = slsToCljsLambda(serverless.service.functions, opts);
+  const compiler = _.get(serverless.service, 'custom.cljsCompiler');
+
   let cmd;
-  if(opts.lumo) {
+  if(compiler == "lumo" || opts.lumo) {
     cmd = (`lumo -c ${path.resolve(__dirname, 'serverless-cljs-plugin')} ` +
            `-m serverless-lumo.build ` +
            `--zip-path ${serverless.service.__cljsArtifact} ` +

--- a/lumo-example/serverless.yml
+++ b/lumo-example/serverless.yml
@@ -1,5 +1,8 @@
 service: lumo-example
 
+custom:
+  cljsCompiler: lumo
+
 provider:
   name: aws
   runtime: nodejs4.3

--- a/serverless-cljs-plugin/serverless_lumo/build.cljs
+++ b/serverless-cljs-plugin/serverless_lumo/build.cljs
@@ -53,7 +53,7 @@
 (defn generate-index
   "Generate the necessary index.js"
   [opts compiler]
-  (index/generate-index (opts :functions) compiler))
+  (index/generate-index (:functions opts) compiler))
 
 (defn write-index [content outpath]
   (.writeFileSync fs outpath content)
@@ -78,17 +78,17 @@
                   :optimizations :none}})
 
 (defn- output-dir [compiler]
-  (let [s (compiler :output-dir)]
+  (let [s (:output-dir compiler)]
     (str/replace s #"/+$" "")))
 
 (defn build!
   "Build a project."
   [opts cljs-lambda-opts]
-  (let [compiler (cljs-lambda-opts :compiler)
+  (let [compiler (:compiler cljs-lambda-opts)
         index    (-> (generate-index opts compiler)
-                     (write-index (.resolve path (opts :zip-path) "../index.js")))]
-    (compile! (cljs-lambda-opts :source-paths) compiler)
-    (zip! (opts :zip-path)
+                     (write-index (.resolve path (:zip-path opts) "../index.js")))]
+    (compile! (:source-paths cljs-lambda-opts) compiler)
+    (zip! (:zip-path opts)
           {:dirs  #{(output-dir compiler) "node_modules"}
            :files #{[index {:name "index.js"}]}}
           compiler)))

--- a/serverless-cljs-plugin/serverless_lumo/build.cljs
+++ b/serverless-cljs-plugin/serverless_lumo/build.cljs
@@ -19,6 +19,10 @@
     (js/Promise.
      (fn [resolve-fn reject-fn]
        (.on output-stream "close" #(resolve-fn output-path))
+       (.on archiver "warning" (fn [err]
+                                 (if (= (.-code err) "ENOENT")
+                                   (js/console.warn (.-message err))
+                                   (reject-fn err))))
        (.on archiver "error" reject-fn)
 
        (.pipe archiver output-stream)

--- a/serverless-cljs-plugin/serverless_lumo/build.cljs
+++ b/serverless-cljs-plugin/serverless_lumo/build.cljs
@@ -1,5 +1,6 @@
 (ns serverless-lumo.build
   (:require fs path archiver
+            [lumo.core]
             [clojure.string :as str]
             [goog.string.format]
             [cljs.reader :as reader]
@@ -109,8 +110,14 @@
                 k (cli-option-map k k)]]
       [k (parse-option k v)])))
 
+(defn cmd-line-args []
+  (if-let [args cljs.core/*command-line-args*] ;; for lumo > 1.7.0
+    args
+    (when-let [args lumo.core/*command-line-args*] ;; for lumo <= 1.7.0
+      args)))
+
 (defn ^:export -main [& args]
-  (let [opts (cli-options *command-line-args*)
+  (let [opts (cli-options (cmd-line-args))
         conf (read-conf!)]
     (build! opts (merge-with merge default-config (read-conf!)))))
 


### PR DESCRIPTION
This patch adds various improvements to the lumo build, notably:

 - handle archiver warning
 - add some useful debug logging
 - fully forward vector as params to archiver's directory() and file()
 - handle `custom.cljsCompiler` option in serverless.yml