### PR TITLE
Use non-deprecated hook for package

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,7 +85,7 @@ class ServerlessPlugin {
       null, serverless, opts);
 
     this.hooks = {
-      'after:deploy:createDeploymentArtifacts': buildAndMerge,
+      'after:package:createDeploymentArtifacts': buildAndMerge,
       'after:deploy:function:packageFunction': buildAndMerge
     };
   }


### PR DESCRIPTION
You can visualize the warning by doing:

`SLS_DEBUG=* serverless package`
