### PR TITLE
Add package --index and cljsIndex options

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,21 @@ The source paths and compiler options will be read from the optional file
                 :optimizations :none}}
 ```
 
+If `package` is called with `--index` or the following is added to
+`serverless.yml`:
+
+```yaml
+custom:
+  cljsIndex: true
+```
+
+A custom `index.js` will be materialized in `:output-dir`'s parent folder. This
+file should be thought as managed by `serverless-cljs-plugin` and can be useful
+for some plugins (e.g.: [`serverless-offline`](https://github.com/dherault/serverless-offline)).
+
+_Note_: with the defaults above `index.js` will be saved, overwriting without
+warning, in the project root (the parent dir of `out`).
+
 ## License
 
 serverless-cljs-plugin is free and unencumbered public domain software. For more

--- a/index.js
+++ b/index.js
@@ -53,13 +53,15 @@ function basepath(config, service, opts) {
 function cljsLambdaBuild(serverless, opts) {
   const fns = slsToCljsLambda(serverless.service.functions, opts);
   const compiler = _.get(serverless.service, 'custom.cljsCompiler');
+  const index = _.get(serverless.service, 'custom.cljsIndex');
 
   let cmd;
   if(compiler == "lumo" || opts.lumo) {
     cmd = (`lumo -c ${path.resolve(__dirname, 'serverless-cljs-plugin')} ` +
            `-m serverless-lumo.build ` +
            `--zip-path ${serverless.service.__cljsArtifact} ` +
-           `--functions '${fns}'`);
+           `--functions '${fns}' ` +
+           `--index ${_.defaultTo(opts.index || index, false)}`);
   } else {
     cmd = (`lein update-in :cljs-lambda assoc :functions '${fns}' ` +
            `-- cljs-lambda build :output ${serverless.service.__cljsArtifact} ` +

--- a/serverless-cljs-plugin/serverless_lumo/index.cljs
+++ b/serverless-cljs-plugin/serverless_lumo/index.cljs
@@ -15,7 +15,11 @@
        {:export  (export-name f)
         :js-name (str (munge ns) "." (munge (name f)))})}))
 
-(defn- generate-index [fns compiler]
+(defn write-index! [content outpath]
+  (.writeFileSync fs outpath content)
+  outpath)
+
+(defn generate-index [fns compiler]
   (.render
    mustache
    (templates (compiler :optimizations))


### PR DESCRIPTION
If either is present, an index.js file will be materialized in the parent
folder of output-dir, which can enhance interop with serverless plugins like
serverless-offline.