### PR TITLE
Graceful lumo exit on compiler failure. Support lumo >= 1.8.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,10 @@ In the example above, there needn't be a corresponding entry for `echo` in
 
 ## Lumo
 
-Alternatively you can use the [Lumo](https://github.com/anmonteiro/lumo)
-[compiler](https://anmonteiro.com/2017/02/compiling-clojurescript-projects-without-the-jvm/).
+Alternatively, you can use the [Lumo](https://github.com/anmonteiro/lumo)
+[compiler](https://anmonteiro.com/2017/09/the-state-of-clojurescript-compilation-in-lumo).
+
+Note that `serverless-cljs-plugin` needs _Lumo >= 1.8.0_.
 
 In order to enable it, pass the `--lumo` switch to either `deploy` or `package`:
 

--- a/lumo-example/README.md
+++ b/lumo-example/README.md
@@ -1,3 +1,3 @@
 # lumo-example
 
-Assuming a local installation of `lumo`, run `serverless package` or `serverless deploy`.
+Assuming a local installation of `lumo` (>= `1.8.0`), run `serverless package` or `serverless deploy`.


### PR DESCRIPTION
This patch fixes the fact that `serverless` could not display compilation ailures because `lumo` was not returning anything. Now `lumo.build.api` accepts a callback that returns the error.
This feature is only available in the latest lumo (>= [1.8.0](https://github.com/anmonteiro/lumo/releases/tag/1.8.0-beta)) so the README now makes clear that other versions won't be supported.