### PR TITLE
Feature/lumo cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,10 @@ custom:
       classpath:
         - /tmp/
       localRepo: /xyz
+      cache: /cache | none
 ```
+
+_Note_: caching is always on unless you specify "none" in the config.
 
 ## License
 


### PR DESCRIPTION
Antonio has introduced incremental builds (https://github.com/anmonteiro/lumo/commit/7c34d011dd8232828a337f361737de0bd3cfd1b4) and caching so this is now relevant.

It adds a `cache` option that can be either a path to a custom folder or `"none"`. If the `cache` key is missing, `lumo` will execute with `--auto-cache`.