### PR TITLE
Change to new artifact property from serverless 1.18.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ function setCljsLambdaFnMap(serverless, opts) {
       if(fn.cljs) {
         fn.handler = `index.${munge.munge(fn.cljs)}`;
         if(!isLumo(serverless, opts)) {
-          _.set(fn, 'package.artifact', serverless.service.__cljsArtifact);
+          fn.artifact = serverless.service.__cljsArtifact;
         }
       }
       return fn;


### PR DESCRIPTION
source: https://github.com/serverless-heaven/serverless-webpack/blob/06e1928924c817034d870e78d7efa5ed04fed66f/lib/packageModules.js#L16

Closes #34 

Note that this will make `deploy function` incompatible with serverless < 1.18.0