### PR TITLE
Lumo :source-map can default to true again

### DIFF
--- a/serverless-cljs-plugin/serverless_lumo/build.cljs
+++ b/serverless-cljs-plugin/serverless_lumo/build.cljs
@@ -34,7 +34,7 @@
   {:source-paths ["src"]
    :compiler     {:output-to     (.format path #js {:dir "out" :base "lambda.js"})
                   :output-dir    "out"
-                  :source-map    false ;; lumo bug
+                  :source-map    true
                   :target        :nodejs
                   :optimizations :none}})
 


### PR DESCRIPTION
The patch for fixing source maps is in so we can default to true again, see
anmonteiro/lumo@913fb9d.