### PR TITLE
Update iodash (vulnerability report from GitHub)

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "bluebird": "3.4.6",
     "jszip": "3.1.4",
-    "lodash": "4.17.2",
+    "lodash": "4.17.5",
     "minimatch": "3.0.4",
     "mkdirp": "0.5.1",
     "mustache": "2.3.0"


### PR DESCRIPTION
Hi.
I receive below vulnerability report from Github.
If there is nothing to worry about, please merge it.

## Remediation
Upgrade lodash to version 4.17.5 or later. For example:
```
"dependencies": {
  "lodash": ">=4.17.5"
}
```
or…
```
"devDependencies": {
  "lodash": ">=4.17.5"
}
```
Always verify the validity and compatibility of suggestions with your codebase.

## Details
CVE-2018-3721 More information
moderate severity
Vulnerable versions: < 4.17.5
Patched version: 4.17.5
lodash node module before 4.17.5 suffers from a Modification of Assumed-Immutable Data (MAID) vulnerability via defaultsDeep, merge, and mergeWith functions, which allows a malicious user to modify the prototype of "Object" via proto, causing the addition or modification of an existing property that will exist on all objects.